### PR TITLE
Set default notice url to the instance-action api

### DIFF
--- a/poll_for_termination.sh
+++ b/poll_for_termination.sh
@@ -18,7 +18,7 @@ MANAGER_IP=$(docker info -f '{{(index .Swarm.RemoteManagers 0).Addr}}' | sed -E 
 MANAGER_ADDR="tcp://$MANAGER_IP:$API_PORT"
 # MANAGER_IP=$(docker info -f '{{json (index .Swarm.RemoteManagers 0).Addr}}')
 
-NOTICE_URL=${NOTICE_URL:-http://169.254.169.254/latest/meta-data/spot/termination-time}
+NOTICE_URL=${NOTICE_URL:-http://169.254.169.254/latest/meta-data/spot/instance-action}
 
 echo "Polling ${NOTICE_URL} every ${POLL_INTERVAL} second(s), Manager: ${MANAGER_ADDR}, Node: ${NODE_ID}"
 


### PR DESCRIPTION
Heya 👋 

The termination-time endpoint is deprecated and only kept in-place for backward compatible reasons. The new metadata endpoint described by the docs is `/spot/instance-action`

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-interruptions.html

Thank you for the repository!

